### PR TITLE
Fix SPI xfer logic to use correct edge and timing

### DIFF
--- a/examples/icezero/Makefile
+++ b/examples/icezero/Makefile
@@ -10,6 +10,9 @@ reset: icezprog
 icezprog: icezprog.c
 	gcc -o icezprog -Wall icezprog.c -lwiringPi -lrt -lstdc++
 
+install_icezprog: icezprog
+	cp icezprog /usr/local/bin/icezprog
+
 icezero.blif: icezero.v memdata.dat defines.vh
 	yosys -p 'synth_ice40 -top top -blif icezero.blif' icezero.v
 

--- a/examples/icezero/Makefile
+++ b/examples/icezero/Makefile
@@ -8,7 +8,7 @@ reset: icezprog
 	./icezprog .
 
 icezprog: icezprog.c
-	gcc -o icezprog -Wall -Os icezprog.c -lwiringPi -lrt -lstdc++
+	gcc -o icezprog -Wall icezprog.c -lwiringPi -lrt -lstdc++
 
 icezero.blif: icezero.v memdata.dat defines.vh
 	yosys -p 'synth_ice40 -top top -blif icezero.blif' icezero.v

--- a/examples/icezero/README.md
+++ b/examples/icezero/README.md
@@ -17,16 +17,27 @@ IceZero Getting Started Guide
 **Step 1:** Get the raspbian image with pre-installed FOSS iCE40 tools:  
 http://files.clifford.at/2017-03-02-raspbian-jessie-icotools.zip
 
-**Step 2:** Unzip the file and write the image on a (min 16 GB) SD card. See this link for instructions:  
+And unzip the file and write the image on a (min 16 GB) SD card. See this link for instructions:  
 https://www.raspberrypi.org/documentation/installation/installing-images/README.md
 
-**Step 3:** Connect your IceZero with your Raspberry Pi or Raspberry Pi Zero and boot
+
+-- or --
+
+Install the icestorm toolchain via:
+
+    sudo apt-get install fpga-icestorm arachne-pnr
+
+**Step 2:** Connect your IceZero with your Raspberry Pi or Raspberry Pi Zero and boot
 the Raspberry Pi from the SD card.
 
-**Step 4:** Copy the files in this directory onto the Raspberry Pi and build the
+**Step 2:** Copy the files in this directory onto the Raspberry Pi and build the
 IceZero programming tool:
 
     make icezprog
+
+and optionally
+
+    sudo make install_icezprog
 
 **Step 5:** Build the example design and program it into the IceZero board:
 

--- a/examples/icezero/icezprog.c
+++ b/examples/icezero/icezprog.c
@@ -296,6 +296,10 @@ int main(int argc, char **argv)
 		} while (size == sizeof(buffer));
 	}
 
+	// Release SPI pins so FPGA can take over
+	pinMode(CFG_SS,   INPUT);
+	pinMode(CFG_SCK,  INPUT);
+	pinMode(CFG_SO,   INPUT);
 	digitalWrite(CFG_RST, HIGH);
 	barrier_sync();
 


### PR DESCRIPTION
This fixes issue #3, and speeds up the flashing process. I've tested this on a vanilla Raspberry Pi Zero W.

pi@fpga:~/git/icotools/examples/icezero $ time ./icezprog ~/Downloads/default_te/python/gpio32_pwm6_te.bin 
Flash ID: EF 70 18 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00 00
Writing 0x000000 .. 0x00ffff: [erasing] [writing................] [readback................]
Writing 0x010000 .. 0x01ffff: [erasing] [writing................] [readback................]
Writing 0x020000 .. 0x02100a: [erasing] [writing..] [readback..]
DONE.